### PR TITLE
Feat: Add onboarding flow with DataStore integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,10 @@ dependencies {
     ksp("com.google.dagger:hilt-compiler:2.55")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
+    // Acompanist
+    implementation("com.google.accompanist:accompanist-pager:0.34.0")
+    implementation("com.google.accompanist:accompanist-pager-indicators:0.34.0")
+
 }
 
 ktlint {

--- a/app/src/main/java/com/mundocode/moneyflow/core/OnboardingDataStore.kt
+++ b/app/src/main/java/com/mundocode/moneyflow/core/OnboardingDataStore.kt
@@ -1,0 +1,29 @@
+package com.mundocode.moneyflow.core
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+val Context.onboardingDataStore by preferencesDataStore("onboarding")
+
+class OnboardingDataStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private val ONBOARDING_KEY = booleanPreferencesKey("onboarding_completed")
+    }
+
+    val onboardingCompletedFlow: Flow<Boolean> = context.onboardingDataStore.data
+        .map { it[ONBOARDING_KEY] ?: false }
+
+    suspend fun setOnboardingCompleted(completed: Boolean) {
+        context.onboardingDataStore.edit {
+            it[ONBOARDING_KEY] = completed
+        }
+    }
+}

--- a/app/src/main/java/com/mundocode/moneyflow/di/OnboardingModule.kt
+++ b/app/src/main/java/com/mundocode/moneyflow/di/OnboardingModule.kt
@@ -1,0 +1,21 @@
+package com.mundocode.moneyflow.di
+
+import android.content.Context
+import com.mundocode.moneyflow.core.OnboardingDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object OnboardingModule {
+
+    @Provides
+    @Singleton
+    fun provideOnboardingDataStore(@ApplicationContext context: Context): OnboardingDataStore {
+        return OnboardingDataStore(context)
+    }
+}

--- a/app/src/main/java/com/mundocode/moneyflow/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/mundocode/moneyflow/navigation/NavigationGraph.kt
@@ -20,6 +20,7 @@ import com.mundocode.moneyflow.ui.screens.gananciasGastos.DetalleTransaccionScre
 import com.mundocode.moneyflow.ui.screens.gananciasGastos.GananciasGastosScreen
 import com.mundocode.moneyflow.ui.screens.gananciasGastos.ListaTransaccionesScreen
 import com.mundocode.moneyflow.ui.screens.home.HomeScreen
+import com.mundocode.moneyflow.ui.screens.onBoarding.OnboardingScreen
 import com.mundocode.moneyflow.ui.screens.proyectos.ProyectosScreen
 import com.mundocode.moneyflow.ui.screens.settings.SettingsScreen
 
@@ -31,6 +32,7 @@ fun NavigationGraph(
 ) {
     NavHost(navController, startDestination = "splash") {
         composable("splash") { SplashScreen(navController = navController) }
+        composable("onboarding") { OnboardingScreen(navController) }
         composable("login") { LoginScreen(navController = navController) }
         composable("register") { RegisterScreen(navController = navController) }
         composable("home") { HomeScreen(navController = navController) }

--- a/app/src/main/java/com/mundocode/moneyflow/ui/screens/SplashScreen.kt
+++ b/app/src/main/java/com/mundocode/moneyflow/ui/screens/SplashScreen.kt
@@ -5,28 +5,44 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.google.firebase.auth.FirebaseAuth
+import com.mundocode.moneyflow.ui.screens.onBoarding.OnboardingViewModel
+import kotlinx.coroutines.delay
 
 @Composable
-fun SplashScreen(navController: NavHostController) {
+fun SplashScreen(
+    navController: NavHostController,
+    onboardingViewModel: OnboardingViewModel = hiltViewModel()
+) {
+    val isCompleted by onboardingViewModel.isCompleted.collectAsState(initial = false)
     val user = FirebaseAuth.getInstance().currentUser
 
     LaunchedEffect(Unit) {
-        if (user != null) {
-            navController.navigate("home") {
+        delay(500) // espera un poco para asegurar que DataStore y Firebase se hayan leído
+
+        if (user == null) {
+            navController.navigate("login") {
                 popUpTo("splash") { inclusive = true }
             }
         } else {
-            navController.navigate("login") {
-                popUpTo("splash") { inclusive = true }
+            if (isCompleted) {
+                navController.navigate("home") {
+                    popUpTo("splash") { inclusive = true }
+                }
+            } else {
+                navController.navigate("onboarding") {
+                    popUpTo("splash") { inclusive = true }
+                }
             }
         }
     }
 
-    // Solo muestra un loader mientras redirige
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         CircularProgressIndicator()
     }

--- a/app/src/main/java/com/mundocode/moneyflow/ui/screens/onBoarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/mundocode/moneyflow/ui/screens/onBoarding/OnboardingScreen.kt
@@ -1,0 +1,111 @@
+package com.mundocode.moneyflow.ui.screens.onBoarding
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import androidx.compose.foundation.pager.PagerState
+
+data class OnboardingPage(val icon: String, val title: String, val description: String)
+
+@Composable
+fun OnboardingScreen(
+    navController: NavHostController,
+    viewModel: OnboardingViewModel = hiltViewModel()
+) {
+    val pages = listOf(
+        OnboardingPage("📱", "Bienvenido", "Tu app financiera para organizar tus ingresos y gastos."),
+        OnboardingPage("💰", "Controla tus gastos", "Categoriza, analiza y predice tus finanzas."),
+        OnboardingPage("📊", "Toma decisiones", "Basado en tus datos reales.")
+    )
+
+    val pagerState = rememberPagerState(
+        pageCount = { pages.size },
+    )
+    val scope = rememberCoroutineScope()
+
+    Scaffold {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) { page ->
+                val item = pages[page]
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(item.icon, fontSize = 60.sp)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(item.title, fontSize = 24.sp, fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        item.description,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            PagerState(
+                currentPage = pagerState.currentPage,
+                currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
+                pageCount = { pagerState.pageCount }
+            )
+
+//            HorizontalPagerIndicator(
+//                pagerState = pagerState,
+//                modifier = Modifier.padding(16.dp)
+//            )
+
+            val loading = remember { mutableStateOf(false) }
+
+            if (loading.value) {
+                CircularProgressIndicator()
+            }
+
+            Button(
+                onClick = {
+                    if (pagerState.currentPage == pages.size - 1) {
+                        scope.launch {
+                            viewModel.markCompletedAsync()
+                            delay(300)
+                            navController.navigate("home") {
+                                popUpTo("onboarding") { inclusive = true }
+                            }
+                        }
+                    } else {
+                        scope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp)
+            ) {
+                Text(text = if (pagerState.currentPage == pages.size - 1) "Comenzar" else "Siguiente")
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/mundocode/moneyflow/ui/screens/onBoarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/mundocode/moneyflow/ui/screens/onBoarding/OnboardingViewModel.kt
@@ -1,0 +1,33 @@
+package com.mundocode.moneyflow.ui.screens.onBoarding
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mundocode.moneyflow.core.OnboardingDataStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.bouncycastle.crypto.params.Blake3Parameters.context
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val onboardingDataStore: OnboardingDataStore
+) : ViewModel() {
+
+    val isCompleted = onboardingDataStore.onboardingCompletedFlow
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
+    fun markCompletedAsync() {
+        viewModelScope.launch {
+            onboardingDataStore.setOnboardingCompleted(true)
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces an onboarding flow to guide new users through the app's features. It utilizes Jetpack DataStore to track the onboarding completion status. The changes include:
- New `OnboardingScreen` composable with a pager for displaying onboarding steps.
- `OnboardingViewModel` to manage the onboarding state and interact with `OnboardingDataStore`.
- `OnboardingDataStore` to persist the onboarding completion status.
- Navigation integration to display the onboarding flow after login if not completed.
- Accompanist Pager dependencies for the onboarding pager.